### PR TITLE
ignore windows error that doesn't impact execution

### DIFF
--- a/appdomain.go
+++ b/appdomain.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package clr
 
@@ -171,7 +171,9 @@ func (obj *AppDomain) Load_3(rawAssembly *SafeArray) (assembly *Assembly, err er
 	)
 
 	if err != syscall.Errno(0) {
-		return
+		if err != syscall.Errno(1150) {
+			return
+		}
 	}
 
 	if hr != S_OK {


### PR DESCRIPTION
I was getting an error when attempting to load correctly-targeted assemblies. 

'The specified program requires a newer version of Windows'

If I unhooked the version check from `kernel32`, it would let me load the assembly and it worked just fine. 
Taking the same assembly and running it via meterpreters exexute-assembly also yielded successful execution. I traced it down to this function, ignored that specific error, and all is now working as expected. 

for lulz - https://twitter.com/4lex/status/1489698612556746757