### PR TITLE
Remove must from go-clr.go

### DIFF
--- a/go-clr.go
+++ b/go-clr.go
@@ -89,16 +89,26 @@ func ExecuteDLLFromDisk(targetRuntime, dllpath, typeName, methodName, argument s
 	}
 
 	pDLLPath, err := syscall.UTF16PtrFromString(dllpath)
-	must(err)
+	if err != nil {
+		return
+	}
 	pTypeName, err := syscall.UTF16PtrFromString(typeName)
-	must(err)
+	if err != nil {
+		return
+	}
 	pMethodName, err := syscall.UTF16PtrFromString(methodName)
-	must(err)
+	if err != nil {
+		return
+	}
 	pArgument, err := syscall.UTF16PtrFromString(argument)
-	must(err)
+	if err != nil {
+		return
+	}
 
 	ret, err := runtimeHost.ExecuteInDefaultAppDomain(pDLLPath, pTypeName, pMethodName, pArgument)
-	must(err)
+	if err != nil {
+		return
+	}
 	if *ret != 0 {
 		return int16(*ret), fmt.Errorf("the ICLRRuntimeHost::ExecuteInDefaultAppDomain method returned a non-zero return value: %d", *ret)
 	}

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,6 @@ package clr
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"strings"
 	"unicode/utf16"
 	"unsafe"
@@ -22,13 +21,6 @@ func checkOK(hr uintptr, caller string) error {
 		return fmt.Errorf("%s returned 0x%08x", caller, hr)
 	} else {
 		return nil
-	}
-}
-
-// must forces the program to exit if there is an error using the log.Fatal command
-func must(err error) {
-	if err != nil {
-		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
We really must remove `must(err)` error handling from `go-clr.go` because it can cause your entire program to bomb out without even the slightest chance of recovery. It makes this library incredibly unstable. If it goes wrong it should return an error, not `log.Fatal(err)`. `log.Fatal` doesn't even allow defer statements to run! It's really bad.

I'm leaving it in the `examples` folder though as it doesn't cause any direct issues there.

Note: I've forked off your fork and I'm creating this PR for to it because I can see that you've made quite a few improvements upon the original repo. Thanks for taking the original and improving it so much!