### PR TITLE
Fix issue where `GetConsoleWindow` misidentifies existing console

### DIFF
--- a/io.go
+++ b/io.go
@@ -71,8 +71,8 @@ func RedirectStdoutStderr() (err error) {
 	getConsoleWindow := kernel32.NewProc("GetConsoleWindow")
 
 	// Ensure the process has a console because if it doesn't there will be no output to capture
-	hConsole, _, _ := getConsoleWindow.Call()
-	if hConsole == 0 {
+	_, _, err = getConsoleWindow.Call()
+	if err != syscall.Errno(0) {
 		// https://learn.microsoft.com/en-us/windows/console/allocconsole
 		allocConsole := kernel32.NewProc("AllocConsole")
 		// BOOL WINAPI AllocConsole(void);
@@ -84,7 +84,7 @@ func RedirectStdoutStderr() (err error) {
 		}
 
 		// Get a handle to the newly created/allocated console
-		hConsole, _, _ = getConsoleWindow.Call()
+		hConsole, _, _ := getConsoleWindow.Call()
 
 		user32 := windows.NewLazySystemDLL("user32.dll")
 		showWindow := user32.NewProc("ShowWindow")


### PR DESCRIPTION
Hi,

Thanks for your great work on this fork! I've been using it in my program, but have been encountering scenarios where I would get `there was an error calling kernel32!AllocConsole with return code 0: Access is denied.` in certain build environments (specifically, when running tests within VS Code). This was caused by a console already being present, but `kernel32!GetConsoleWindow` returning 0 as a handle value somehow.

I fixed this scenario by changing the check for existing console window to match on the error value instead of the handle value. If the error is not `ERROR_SUCCESS` the code will proceed to create its own console.